### PR TITLE
Choose filters to apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ lint = [
     "ruff>=0.8.0,<0.9.0",
 ]
 test = [
+    "invoke>=2.2.0",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-sugar>=1.0.0",

--- a/typogrify/filters.py
+++ b/typogrify/filters.py
@@ -381,6 +381,8 @@ def applyfilters(text, **kwargs):
         text = caps(text)
     if kwargs.pop("initial_quotes", True):
         text = initial_quotes(text)
+    if kwargs.pop("widont", True):
+        text = widont(text)
     if kwargs:
         raise TypeError("Unexpected keyword argument(s): %s" % list(kwargs.keys()))
     return text
@@ -398,14 +400,8 @@ def typogrify(text, ignore_tags=None, **kwargs):
     >>> typogrify('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>')
     '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class="caps">KU</span> fans act extremely&nbsp;obnoxiously</h2>'
 
-    >>> typogrify('<div>"Jayhawks" & KU fans act extremely obnoxiously</div>', ignore_tags=["div"])
-    '<div>"Jayhawks" & KU fans act extremely obnoxiously</div>'
-
-    The widont filter ignores the ignore_tags list, because it applies to
-    predetermined set of tags.
-
     >>> typogrify('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>', ignore_tags=["h2"])
-    '<h2>"Jayhawks" & KU fans act extremely&nbsp;obnoxiously</h2>'
+    '<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>'
 
     Any filter may be disabled by setting its corresponding keyword argument to
     False.
@@ -428,7 +424,6 @@ def typogrify(text, ignore_tags=None, **kwargs):
     >>> typogrify('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>', amp=False, smartypants=False, caps=False, initial_quotes=False, widont=False)
     '<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>'
     """
-    apply_widont = kwargs.pop("widont", True)
     section_list = process_ignores(text, ignore_tags)
 
     rendered_text = ""
@@ -438,9 +433,6 @@ def typogrify(text, ignore_tags=None, **kwargs):
         else:
             rendered_text += text_item
 
-    # Apply widont at the end, as its already smart about tags. Hopefully.
-    if apply_widont:
-        rendered_text = widont(rendered_text)
     return rendered_text
 
 


### PR DESCRIPTION
Following up on getpelican/pelican#3436, here's a take at making the `typogrify()` function more flexible by allowing one to select which filters to apply.

Some remarks about the proposed changes:

- To keep the new keyword arguments to `applyfilters()` and `typogrify()` short while avoiding name clashes with their corresponding filter functions, they are accessed through `kwargs.pop()`. That makes the function signatures less self-explanatory, but I am mentioning the keyword arguments in the docstrings.
- I have moved a doctest from `applyfilters()` to `typogrify()`, because it was specifically testing `typogrify()`.
- I have added doctests for the new options.
- I have noticed that `widont` ignores the `ignore_tags` list, and then discovered that this issue had already been reported in mintchaos/typogrify#30. I have added a comment and a test about this behavior. I understand that `widont` only applies to a hardcoded list of tags, but it probably makes the API less predictable to one who wouldn't fully read the documentation or code. However, this would perhaps be better addressed separately from this PR.
