### PR TITLE
Remove wrong shebang from tests.py

### DIFF
--- a/typogrify/packages/titlecase/tests.py
+++ b/typogrify/packages/titlecase/tests.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 
 """Tests for titlecase"""
 


### PR DESCRIPTION
The `tests.py` file cannot be executed directly:
```
$ chmod +x typogrify/packages/titlecase/tests.py
$ typogrify/packages/titlecase/tests.py
Traceback (most recent call last):
  File "/data/builds/typogrify/typogrify/packages/titlecase/tests.py", line 12, in <module>
    from . import titlecase
ImportError: attempted relative import with no known parent package
$
```
and so it makes no sense to keep the python shebang there.